### PR TITLE
Update ipa.py

### DIFF
--- a/lib/ipa.py
+++ b/lib/ipa.py
@@ -40,12 +40,12 @@ def ipaScan(filePath, save):
     try:
         iOSInfo(appInfoPath)
         iOSAuthority(appInfoPath)
-        iOSCert(appInfoPath, filePath, appBinPath)
         console.print('[magenta]Reverse [/magenta][bold magenta]' + appBinPath + '[/bold magenta]')
         reverse(filePath, appBinPath)
         console.print('[bold green]Finish[/bold green]')
         iOSMachO(appBinPath, filePath)
         iOSRpath(filePath + '/RpathDump')
+        iOSCert(appInfoPath, filePath, appBinPath)
         for key in scanners.keys():
             c = scanner(key)
             if c:


### PR DESCRIPTION
iOSCert需要读取的macho.json文件在iOSMachO调用后才会生成，先运行iOSCert会导致读取macho.json失败而报错